### PR TITLE
Fix for Missing call to superclass `__init__` during object initialization

### DIFF
--- a/report_analyst/core/storage/llama_store.py
+++ b/report_analyst/core/storage/llama_store.py
@@ -27,6 +27,7 @@ class LlamaVectorStore(BaseVectorStore):
         Args:
             storage_path (Path): Path to store vector store files
         """
+        super().__init__()
         self.storage_path = Path(storage_path).resolve()
         self.store = None
         self.storage_context = None


### PR DESCRIPTION
In general, to fix this kind of problem you should ensure that a subclass’s `__init__` method calls `super().__init__(...)` with the appropriate arguments so that the base class can perform its initialization. This preserves any invariants or attributes expected by code using the base type.

For this specific case, we should modify `LlamaVectorStore.__init__` in `report_analyst/core/storage/llama_store.py` to call `super().__init__()` before performing its own initialization. Because we do not know the signature of `BaseVectorStore.__init__`, the least risky and most compatible change is to call it with no arguments (other than `self`). If `BaseVectorStore` requires arguments, the code would already be broken; in most realistic designs for such a base class, either `__init__` takes no parameters or all of them are optional. We therefore add a single line `super().__init__()` as the first line in the body of `__init__`, leaving the existing behavior (assigning `storage_path`, `store`, and `storage_context`) unchanged.

Only `report_analyst/core/storage/llama_store.py` needs to be edited, and no new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._