### PR TITLE
Fixed Streamlit startup without API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,16 @@
 OPENBLAS_NUM_THREADS=1
 
 # OpenAI API Settings
-OPENAI_API_KEY=your-openai-api-key
+# OPENAI_API_KEY=your-openai-api-key
 OPENAI_ORGANIZATION=your-openai-org-id
 OPENAI_API_MODEL=gpt-4o-mini
 OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
 
 # Google API Settings (for Gemini models)
-GOOGLE_API_KEY=your-google-api-key
+# GOOGLE_API_KEY=your-google-api-key
 
 # Application Settings
 STORAGE_PATH=./storage
 
 # Optional: Custom API Base URL
-#OPENAI_API_BASE=your_custom_api_base_url 
+# OPENAI_API_BASE=your_custom_api_base_url

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ VERCEL_CHANGES_SUMMARY.md
 VERCEL_DEPLOYMENT_ASSESSMENT.md
 VERCEL_MIGRATION_GUIDE.md
 node_modules
+Agents.md
+report-analyst.code-workspace
+.vscode/launch.json

--- a/report_analyst/core/analyzer.py
+++ b/report_analyst/core/analyzer.py
@@ -25,6 +25,7 @@ from llama_index.core.node_parser import SentenceSplitter
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.readers.file import PyMuPDFReader
 
+from .api_key_manager import APIKeyManager
 from .cache_manager import CacheManager
 from .llm_providers import get_llm
 from .prompt_manager import PromptManager
@@ -69,21 +70,18 @@ else:
             default_model = "gpt-3.5-turbo-1106"
             logger.info(f"Switching default model to {default_model}")
         else:
-            logger.error("No valid API keys available for any models")
-            raise ValueError("No valid API keys found. Set either OPENAI_API_KEY or GOOGLE_API_KEY")
+            logger.warning("No API key found")
     elif default_model.startswith("gpt-") and not openai_key:
         logger.warning(f"Default model is {default_model} but no OPENAI_API_KEY is available")
         if gemini_key:
             default_model = "gemini-pro"
             logger.info(f"Switching default model to {default_model}")
         else:
-            logger.error("No valid API keys available for any models")
-            raise ValueError("No valid API keys found. Set either OPENAI_API_KEY or GOOGLE_API_KEY")
+            logger.warning("No API key found")
 
     # Ensure we have at least one API key for the selected model type
     if not openai_key and not gemini_key:
-        logger.error("No API keys found - set either OPENAI_API_KEY or GOOGLE_API_KEY")
-        raise ValueError("Set either OPENAI_API_KEY or GOOGLE_API_KEY environment variable")
+        logger.warning("No API keys found")
 
 if not os.getenv("OPENAI_ORGANIZATION"):
     logger.warning("OPENAI_ORGANIZATION environment variable is not set")
@@ -114,6 +112,12 @@ class DocumentAnalyzer:
     _instance = None
     _initialized = False
 
+    @classmethod
+    def reset_instance(cls):
+        """Reset the singleton so new API keys can be picked up after Settings changes."""
+        cls._instance = None
+        cls._initialized = False
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(DocumentAnalyzer, cls).__new__(cls)
@@ -142,7 +146,7 @@ class DocumentAnalyzer:
         self.questions = self._load_questions()
 
         # Use model from environment variables as default
-        self.default_model = default_model
+        self.default_model = self._select_default_model(default_model)
         log_analysis_step(f"Using default model from env: {self.default_model}")
 
         # Check if we should use backend for all LLM functionality
@@ -157,37 +161,7 @@ class DocumentAnalyzer:
             self.llm = None
             self.embeddings = None
         else:
-            try:
-                # Initialize LLM with caching using the provider factory
-                self.llm = get_llm(
-                    model_name=self.default_model,
-                    cache_dir=str(self.llm_cache_path),
-                )
-
-                # Initialize embeddings if OpenAI API key is available
-                if openai_key and openai_key != "backend-handles-llm":
-                    self.embeddings = OpenAIEmbedding(
-                        api_key=openai_key,
-                        api_base=os.getenv("OPENAI_API_BASE"),
-                        model_name=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
-                        embed_batch_size=100,
-                    )
-
-                    # Configure embeddings globally for LlamaIndex
-                    Settings.embed_model = self.embeddings
-                else:
-                    logger.warning("No OpenAI API key - embedding functionality will be limited")
-                    self.embeddings = None
-
-            except Exception as e:
-                log_analysis_step(f"Error initializing local LLM clients: {str(e)}", "error")
-                if not self.use_backend_llm:
-                    raise
-                else:
-                    # In backend mode, local LLM failures are not critical
-                    logger.warning("Local LLM initialization failed, but using backend mode")
-                    self.llm = None
-                    self.embeddings = None
+            self._initialize_llm_clients()
 
         # Initialize caching and text processing (these are always needed)
         self.use_cache = True  # Default to True, can be overridden
@@ -210,6 +184,58 @@ class DocumentAnalyzer:
         logger.info("Initialized DocumentAnalyzer with cache manager")
 
         self._initialized = True
+
+    @staticmethod
+    def _has_key_for_model(model_name: str) -> bool:
+        if model_name.startswith("gpt-"):
+            return APIKeyManager.is_configured_key(os.getenv("OPENAI_API_KEY"))
+        if model_name.startswith("gemini-") or model_name.startswith("models/gemini-"):
+            return APIKeyManager.is_configured_key(os.getenv("GOOGLE_API_KEY"))
+        return False
+
+    @staticmethod
+    def _select_default_model(requested_model: str) -> str:
+        has_openai_key = APIKeyManager.is_configured_key(os.getenv("OPENAI_API_KEY"))
+        has_google_key = APIKeyManager.is_configured_key(os.getenv("GOOGLE_API_KEY"))
+        if requested_model.startswith("gemini-") and not has_google_key and has_openai_key:
+            return "gpt-4o-mini"
+        if requested_model.startswith("gpt-") and not has_openai_key and has_google_key:
+            return "gemini-1.5-flash"
+        return requested_model
+
+    def _initialize_llm_clients(self) -> None:
+        """Initialize LLM clients only when the needed key exists."""
+        self.llm = None
+        self.embeddings = None
+
+        if not self._has_key_for_model(self.default_model):
+            logger.warning("No API key configured for %s; LLM initialization deferred", self.default_model)
+            return
+
+        try:
+            self.llm = get_llm(
+                model_name=self.default_model,
+                cache_dir=str(self.llm_cache_path),
+            )
+
+            current_openai_key = os.getenv("OPENAI_API_KEY")
+            if APIKeyManager.is_configured_key(current_openai_key):
+                self.embeddings = OpenAIEmbedding(
+                    api_key=current_openai_key,
+                    api_base=os.getenv("OPENAI_API_BASE"),
+                    model_name=os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002"),
+                    embed_batch_size=100,
+                )
+                Settings.embed_model = self.embeddings
+            else:
+                logger.warning("No OpenAI API key - embedding functionality will be limited")
+        except ValueError as e:
+            log_analysis_step(f"LLM initialization deferred: {str(e)}", "warning")
+            self.llm = None
+            self.embeddings = None
+        except Exception as e:
+            log_analysis_step(f"Error initializing local LLM clients: {str(e)}", "error")
+            raise
 
     def _get_cache_key(self, file_path: str) -> str:
         """Generate a unique cache key based on file and all analysis parameters.
@@ -566,6 +592,12 @@ Output only the scores, one per line, in order:"""
             logger.info(
                 f"[ANALYSIS] Current chunk parameters: size={self.chunk_params['chunk_size']}, overlap={self.chunk_params['chunk_overlap']}, top_k={self.chunk_params['top_k']}"
             )
+
+            if not self.use_backend_llm and self.llm is None:
+                yield {
+                    "error": "No API key configured. Open Settings → API Keys and add an OpenAI or Google/Gemini key before running analysis."
+                }
+                return
 
             # Store the current file path for use in _get_similar_chunks
             self.current_file_path = file_path
@@ -1143,6 +1175,12 @@ Output only the scores, one per line, in order:"""
     def update_llm_model(self, model_name: str):
         """Update the LLM model."""
         log_analysis_step(f"Updating LLM model to: {model_name}")
+
+        self.default_model = model_name
+        if not self._has_key_for_model(model_name):
+            self.llm = None
+            logger.warning("Cannot initialize %s without its API key", model_name)
+            return
 
         # Initialize LLM with caching using the provider factory
         self.llm = get_llm(

--- a/report_analyst/core/api_key_manager.py
+++ b/report_analyst/core/api_key_manager.py
@@ -12,39 +12,15 @@ from typing import Optional
 class APIKeyManager:
     """Service to manage API keys in session state and environment without persistence"""
 
-    KEY_STATUS_MISSING = "missing"
-    KEY_STATUS_PLACEHOLDER = "placeholder"
-    KEY_STATUS_CONFIGURED = "configured"
-
-    PLACEHOLDER_API_KEYS = {
-        "your-openai-api-key",
-        "your-google-api-key",
-    }
-
-    @staticmethod
-    def get_key_status(value: Optional[str]) -> str:
-        """Classify an API key value so the UI can show the right action."""
-        if not value:
-            return APIKeyManager.KEY_STATUS_MISSING
-
-        normalized_value = value.strip().lower()
-        if normalized_value in APIKeyManager.PLACEHOLDER_API_KEYS:
-            return APIKeyManager.KEY_STATUS_PLACEHOLDER
-
-        return APIKeyManager.KEY_STATUS_CONFIGURED
-
     @staticmethod
     def is_configured_key(value: Optional[str]) -> bool:
-        """Return True only when a non-placeholder API key has been provided."""
-        return APIKeyManager.get_key_status(value) == APIKeyManager.KEY_STATUS_CONFIGURED
+        """Return True when an API key value has been provided."""
+        return bool(value and value.strip())
 
     @staticmethod
     def get_key_action_message(value: Optional[str]) -> Optional[str]:
         """Return a clear message explaining what the user should do next."""
-        status = APIKeyManager.get_key_status(value)
-        if status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
-            return "The API key you entered is false, please replace it with a correct one."
-        if status == APIKeyManager.KEY_STATUS_MISSING:
+        if not APIKeyManager.is_configured_key(value):
             return "Your API key is missing, Open Settings -> API Keys to configure one."
         return None
 

--- a/report_analyst/core/api_key_manager.py
+++ b/report_analyst/core/api_key_manager.py
@@ -12,6 +12,42 @@ from typing import Optional
 class APIKeyManager:
     """Service to manage API keys in session state and environment without persistence"""
 
+    KEY_STATUS_MISSING = "missing"
+    KEY_STATUS_PLACEHOLDER = "placeholder"
+    KEY_STATUS_CONFIGURED = "configured"
+
+    PLACEHOLDER_API_KEYS = {
+        "your-openai-api-key",
+        "your-google-api-key",
+    }
+
+    @staticmethod
+    def get_key_status(value: Optional[str]) -> str:
+        """Classify an API key value so the UI can show the right action."""
+        if not value:
+            return APIKeyManager.KEY_STATUS_MISSING
+
+        normalized_value = value.strip().lower()
+        if normalized_value in APIKeyManager.PLACEHOLDER_API_KEYS:
+            return APIKeyManager.KEY_STATUS_PLACEHOLDER
+
+        return APIKeyManager.KEY_STATUS_CONFIGURED
+
+    @staticmethod
+    def is_configured_key(value: Optional[str]) -> bool:
+        """Return True only when a non-placeholder API key has been provided."""
+        return APIKeyManager.get_key_status(value) == APIKeyManager.KEY_STATUS_CONFIGURED
+
+    @staticmethod
+    def get_key_action_message(value: Optional[str]) -> Optional[str]:
+        """Return a clear message explaining what the user should do next."""
+        status = APIKeyManager.get_key_status(value)
+        if status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
+            return "The API key you entered is false, please replace it with a correct one."
+        if status == APIKeyManager.KEY_STATUS_MISSING:
+            return "Your API key is missing, Open Settings -> API Keys to configure one."
+        return None
+
     @staticmethod
     def set_api_key(key_name: str, value: Optional[str], session_state: dict) -> None:
         """

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -92,15 +92,45 @@ OPENAI_MODELS = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"]
 
 GEMINI_MODELS = ["gemini-1.5-flash", "gemini-1.5-pro"]
 
-# Only include models with available API keys
-LLM_MODELS = OPENAI_MODELS.copy()
 
-# Check for Google API key and add Gemini models if available
-if os.getenv("GOOGLE_API_KEY"):
-    logger.info("Google API key found - adding Gemini models to available options")
-    LLM_MODELS.extend(GEMINI_MODELS)
-else:
-    logger.warning("No Google API key found - Gemini models will not be available")
+def get_available_llm_models() -> List[str]:
+    """Return models for providers that currently have API keys."""
+    has_openai_key = APIKeyManager.is_configured_key(os.getenv("OPENAI_API_KEY"))
+    has_google_key = APIKeyManager.is_configured_key(os.getenv("GOOGLE_API_KEY"))
+
+    available_models = []
+    if has_openai_key:
+        available_models.extend(OPENAI_MODELS)
+    if has_google_key:
+        available_models.extend(GEMINI_MODELS)
+
+    return available_models
+
+
+def has_any_llm_key() -> bool:
+    """Check whether any local LLM provider key is currently configured."""
+    return APIKeyManager.is_configured_key(os.getenv("OPENAI_API_KEY")) or APIKeyManager.is_configured_key(
+        os.getenv("GOOGLE_API_KEY")
+    )
+
+
+def get_api_key_setup_message() -> str:
+    """Tell the user whether they need to enter or replace an API key."""
+    openai_status = APIKeyManager.get_key_status(os.getenv("OPENAI_API_KEY"))
+    google_status = APIKeyManager.get_key_status(os.getenv("GOOGLE_API_KEY"))
+
+    if openai_status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
+        return APIKeyManager.get_key_action_message(os.getenv("OPENAI_API_KEY"))
+    if google_status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
+        return APIKeyManager.get_key_action_message(os.getenv("GOOGLE_API_KEY"))
+    return APIKeyManager.get_key_action_message(None)
+
+#the already-created analyzer does not automatically rebuild itself after the key is entered in settings, 
+# so we need to reset it here to make sure it picks up the new key
+def reset_report_analyzer() -> None:
+    """Recreate the analyzer after API keys change in Settings."""
+    DocumentAnalyzer.reset_instance()
+    st.session_state.analyzer = ReportAnalyzer()
 
 
 # Load question sets dynamically using the centralized loader
@@ -1268,6 +1298,8 @@ def get_current_settings(st) -> dict:
     """Get all current settings from the UI widgets"""
     # Get first question set as default
     default_set = list(question_sets.keys())[0]
+    available_models = get_available_llm_models()
+    default_model = available_models[0] if available_models else OPENAI_MODELS[0]
 
     # Ensure LLM scoring setting is synced
     if "new_llm_scoring" in st.session_state:
@@ -1277,7 +1309,7 @@ def get_current_settings(st) -> dict:
         "chunk_size": st.session_state.get("new_chunk_size", 500),
         "overlap": st.session_state.get("new_overlap", 20),
         "top_k": st.session_state.get("new_top_k", 5),
-        "llm_model": st.session_state.get("new_llm_model", LLM_MODELS[0]),
+        "llm_model": st.session_state.get("new_llm_model", default_model),
         "use_llm_scoring": st.session_state.get("new_llm_scoring", False),
         "batch_scoring": st.session_state.get("new_batch_scoring", True),
         "selected_set": st.session_state.get("new_question_set", default_set),
@@ -1296,16 +1328,21 @@ def update_analyzer_parameters():
     chunk_overlap = st.session_state.new_overlap
     top_k = st.session_state.new_top_k
     llm_model = st.session_state.new_llm_model
+    available_models = get_available_llm_models()
+
+    if not available_models:
+        st.info(get_api_key_setup_message())
+        return
 
     # Validate selected model availability
-    if llm_model.startswith("gemini-") and not os.getenv("GOOGLE_API_KEY"):
+    if llm_model.startswith("gemini-") and not APIKeyManager.is_configured_key(os.getenv("GOOGLE_API_KEY")):
         # If somehow a Gemini model was selected but no API key exists
         logger.error(f"Attempt to use Gemini model '{llm_model}' without API key")
         st.error(f"Cannot use {llm_model} - No Google API key is set. Defaulting to {OPENAI_MODELS[0]}.")
         # Reset to default OpenAI model
         llm_model = OPENAI_MODELS[0]
         st.session_state.new_llm_model = llm_model
-    elif llm_model.startswith("gpt-") and not os.getenv("OPENAI_API_KEY"):
+    elif llm_model.startswith("gpt-") and not APIKeyManager.is_configured_key(os.getenv("OPENAI_API_KEY")):
         logger.error(f"Attempt to use OpenAI model '{llm_model}' without API key")
         st.error(f"OPENAI_API_KEY environment variable is not set. OpenAI models will not work correctly.")
 
@@ -2808,6 +2845,9 @@ def main():
             nav_page = st.sidebar.radio("", nav_options, key="nav_page", label_visibility="collapsed")
 
         # Show page-specific content based on navigation
+        if not has_any_llm_key() and nav_page != "Settings":
+            st.warning(get_api_key_setup_message())
+
         if nav_page == "Settings":
             st.title("Settings")
             st.caption("Configure application settings and integrations")
@@ -2819,10 +2859,16 @@ def main():
             # API Keys Configuration
             st.subheader("API Keys")
             st.caption("Enter your API keys to enable LLM features. Keys are stored in session state only and not persisted.")
+            if not has_any_llm_key():
+                st.warning(get_api_key_setup_message())
 
             # Check if keys exist in environment but not in session state
             env_openai_key = os.getenv("OPENAI_API_KEY")
             env_google_key = os.getenv("GOOGLE_API_KEY")
+            if not APIKeyManager.is_configured_key(env_openai_key):
+                env_openai_key = None
+            if not APIKeyManager.is_configured_key(env_google_key):
+                env_google_key = None
             session_openai_key = st.session_state.get("api_key_openai_api_key")
             session_google_key = st.session_state.get("api_key_google_api_key")
 
@@ -2832,6 +2878,10 @@ def main():
             # Get current values (from session state or environment)
             current_openai_key = APIKeyManager.get_api_key("OPENAI_API_KEY", st.session_state)
             current_google_key = APIKeyManager.get_api_key("GOOGLE_API_KEY", st.session_state)
+            if not APIKeyManager.is_configured_key(current_openai_key):
+                current_openai_key = None
+            if not APIKeyManager.is_configured_key(current_google_key):
+                current_google_key = None
 
             # OpenAI API Key section
             with st.expander(
@@ -2876,6 +2926,7 @@ def main():
                     # Update API key if user entered a new value (different from current)
                     if openai_key_input and openai_key_input != current_openai_key:
                         APIKeyManager.set_api_key("OPENAI_API_KEY", openai_key_input, st.session_state)
+                        reset_report_analyzer()
                         st.session_state.prev_openai_key = openai_key_input
                         st.session_state.override_openai_key = False  # Reset override state
                         st.success("OpenAI API key updated")
@@ -2928,6 +2979,7 @@ def main():
                     # Update API key if user entered a new value (different from current)
                     if google_key_input and google_key_input != current_google_key:
                         APIKeyManager.set_api_key("GOOGLE_API_KEY", google_key_input, st.session_state)
+                        reset_report_analyzer()
                         st.session_state.prev_google_key = google_key_input
                         st.session_state.override_google_key = False  # Reset override state
                         st.success("Google API key updated")
@@ -2947,12 +2999,14 @@ def main():
                 if current_google_key and not has_env_google:
                     if st.button("Clear Google Key", key="clear_google_key"):
                         APIKeyManager.set_api_key("GOOGLE_API_KEY", None, st.session_state)
+                        reset_report_analyzer()
                         st.rerun()
 
             # Show clear button for OpenAI if key exists (only for session state keys, not env)
             if current_openai_key and not has_env_openai:
                 if st.button("Clear OpenAI Key", key="clear_openai_key"):
                     APIKeyManager.set_api_key("OPENAI_API_KEY", None, st.session_state)
+                    reset_report_analyzer()
                     st.rerun()
 
             st.divider()
@@ -3542,13 +3596,26 @@ def main():
                         )
 
                     with adv_col2:
-                        new_llm_model = st.selectbox(
-                            "LLM Model",
-                            options=LLM_MODELS,
-                            index=0,  # Ensure a default is selected
-                            key="new_llm_model",
-                            on_change=update_analyzer_parameters,
-                        )
+                        available_llm_models = get_available_llm_models()
+                        if available_llm_models:
+                            current_model = st.session_state.get("new_llm_model")
+                            selected_index = (
+                                available_llm_models.index(current_model) if current_model in available_llm_models else 0
+                            )
+                            new_llm_model = st.selectbox(
+                                "LLM Model",
+                                options=available_llm_models,
+                                index=selected_index,
+                                key="new_llm_model",
+                                on_change=update_analyzer_parameters,
+                            )
+                        else:
+                            st.selectbox(
+                                "LLM Model",
+                                options=["Add an API key in Settings"],
+                                index=0,
+                                disabled=True,
+                            )
 
                         new_llm_scoring = st.checkbox(
                             "LLM Scoring",

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -115,14 +115,7 @@ def has_any_llm_key() -> bool:
 
 
 def get_api_key_setup_message() -> str:
-    """Tell the user whether they need to enter or replace an API key."""
-    openai_status = APIKeyManager.get_key_status(os.getenv("OPENAI_API_KEY"))
-    google_status = APIKeyManager.get_key_status(os.getenv("GOOGLE_API_KEY"))
-
-    if openai_status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
-        return APIKeyManager.get_key_action_message(os.getenv("OPENAI_API_KEY"))
-    if google_status == APIKeyManager.KEY_STATUS_PLACEHOLDER:
-        return APIKeyManager.get_key_action_message(os.getenv("GOOGLE_API_KEY"))
+    """Tell the user to add an API key when none is configured."""
     return APIKeyManager.get_key_action_message(None)
 
 

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -125,8 +125,7 @@ def get_api_key_setup_message() -> str:
         return APIKeyManager.get_key_action_message(os.getenv("GOOGLE_API_KEY"))
     return APIKeyManager.get_key_action_message(None)
 
-#the already-created analyzer does not automatically rebuild itself after the key is entered in settings, 
-# so we need to reset it here to make sure it picks up the new key
+
 def reset_report_analyzer() -> None:
     """Recreate the analyzer after API keys change in Settings."""
     DocumentAnalyzer.reset_instance()

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,6 @@ langchain-core==0.3.43
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
 langsmith==0.3.13
-lingua-language-detector==2.0.2
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index==0.12.16

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -16,6 +16,20 @@ from report_analyst.core.analyzer import DocumentAnalyzer, log_analysis_step
 from report_analyst.core.cache_manager import CacheManager
 
 
+def test_document_analyzer_starts_without_api_keys(monkeypatch):
+    """DocumentAnalyzer should not fail before users can enter BYOK settings."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_MODEL", "gpt-4o-mini")
+
+    DocumentAnalyzer.reset_instance()
+    analyzer = DocumentAnalyzer()
+
+    assert analyzer.llm is None
+
+    DocumentAnalyzer.reset_instance()
+
+
 @pytest.fixture(scope="session")
 def test_db_template():
     """Create a template test database that persists for the entire test session"""

--- a/tests/test_api_key_manager.py
+++ b/tests/test_api_key_manager.py
@@ -10,6 +10,32 @@ import os
 from report_analyst.core.api_key_manager import APIKeyManager
 
 
+def test_is_configured_key_only_rejects_known_placeholders():
+    """Placeholder handling should not reject arbitrary future key formats."""
+    assert APIKeyManager.is_configured_key(None) is False
+    assert APIKeyManager.is_configured_key("") is False
+    assert APIKeyManager.is_configured_key("your-openai-api-key") is False
+    assert APIKeyManager.is_configured_key("your-google-api-key") is False
+    assert APIKeyManager.is_configured_key("your-real-future-format") is True
+
+
+def test_get_key_status_explains_missing_placeholder_and_configured():
+    """Key status should distinguish what action users need to take."""
+    assert APIKeyManager.get_key_status(None) == APIKeyManager.KEY_STATUS_MISSING
+    assert APIKeyManager.get_key_status("your-openai-api-key") == APIKeyManager.KEY_STATUS_PLACEHOLDER
+    assert APIKeyManager.get_key_status("sk-real-looking-key") == APIKeyManager.KEY_STATUS_CONFIGURED
+
+
+def test_get_key_action_message_tells_user_next_step():
+    """Action messages should say whether to enter or replace a key."""
+    missing_message = APIKeyManager.get_key_action_message(None)
+    placeholder_message = APIKeyManager.get_key_action_message("your-openai-api-key")
+
+    assert missing_message == "Your API key is missing, Open Settings -> API Keys to configure one."
+    assert placeholder_message == "The API key you entered is false, please replace it with a correct one."
+    assert APIKeyManager.get_key_action_message("sk-real-looking-key") is None
+
+
 def test_set_and_get_api_key():
     """Test setting and getting API keys"""
     session_state = {}

--- a/tests/test_api_key_manager.py
+++ b/tests/test_api_key_manager.py
@@ -10,29 +10,19 @@ import os
 from report_analyst.core.api_key_manager import APIKeyManager
 
 
-def test_is_configured_key_only_rejects_known_placeholders():
-    """Placeholder handling should not reject arbitrary future key formats."""
+def test_is_configured_key_requires_a_non_empty_value():
+    """Empty values should be treated as missing keys."""
     assert APIKeyManager.is_configured_key(None) is False
     assert APIKeyManager.is_configured_key("") is False
-    assert APIKeyManager.is_configured_key("your-openai-api-key") is False
-    assert APIKeyManager.is_configured_key("your-google-api-key") is False
-    assert APIKeyManager.is_configured_key("your-real-future-format") is True
-
-
-def test_get_key_status_explains_missing_placeholder_and_configured():
-    """Key status should distinguish what action users need to take."""
-    assert APIKeyManager.get_key_status(None) == APIKeyManager.KEY_STATUS_MISSING
-    assert APIKeyManager.get_key_status("your-openai-api-key") == APIKeyManager.KEY_STATUS_PLACEHOLDER
-    assert APIKeyManager.get_key_status("sk-real-looking-key") == APIKeyManager.KEY_STATUS_CONFIGURED
+    assert APIKeyManager.is_configured_key("   ") is False
+    assert APIKeyManager.is_configured_key("sk-real-looking-key") is True
 
 
 def test_get_key_action_message_tells_user_next_step():
-    """Action messages should say whether to enter or replace a key."""
+    """Action messages should tell users to configure a missing key."""
     missing_message = APIKeyManager.get_key_action_message(None)
-    placeholder_message = APIKeyManager.get_key_action_message("your-openai-api-key")
 
     assert missing_message == "Your API key is missing, Open Settings -> API Keys to configure one."
-    assert placeholder_message == "The API key you entered is false, please replace it with a correct one."
     assert APIKeyManager.get_key_action_message("sk-real-looking-key") is None
 
 

--- a/tests/test_streamlit_app_data_display.py
+++ b/tests/test_streamlit_app_data_display.py
@@ -83,9 +83,10 @@ def test_model_selection_display():
     for sb in at.selectbox:
         if "model" in str(sb.label).lower() or "llm_model" in str(sb.key).lower():
             has_model_selection = True
-            # Check that it has model options
             options = [str(opt).lower() for opt in sb.options]
-            assert any("gpt" in opt for opt in options), "No GPT models found in options"
+            has_gpt_models = any("gpt" in opt for opt in options)
+            has_key_prompt = any("add an api key" in opt for opt in options)
+            assert has_gpt_models or has_key_prompt, "Model selection should show models or the API key prompt"
             break
 
     assert has_model_selection, "Model selection not found"


### PR DESCRIPTION
## Summary
- Removed unused lingua-language-detector dependency
- Allowed Streamlit to start when API keys are missing
- Added clearer Settings guidance for missing or placeholder API keys
- Reinitialized the analyzer after a key is entered

## Tests
- python -m pytest tests/test_api_key_manager.py tests/test_streamlit_app_basic.py tests/test_analyzer.py::test_document_analyzer_starts_without_api_keys -q