### PR TITLE
Styled missing API key message

### DIFF
--- a/report_analyst/core/analyzer.py
+++ b/report_analyst/core/analyzer.py
@@ -595,7 +595,11 @@ Output only the scores, one per line, in order:"""
 
             if not self.use_backend_llm and self.llm is None:
                 yield {
-                    "error": "No API key configured. Open Settings → API Keys and add an OpenAI or Google/Gemini key before running analysis."
+                    "error": (
+                        "No API key configured. Add an OpenAI or Google/Gemini key in Settings → API Keys "
+                        "for this session. For permanent access: ask your system administrator to configure it "
+                        "in the environment."
+                    )
                 }
                 return
 

--- a/report_analyst/core/api_key_manager.py
+++ b/report_analyst/core/api_key_manager.py
@@ -21,7 +21,10 @@ class APIKeyManager:
     def get_key_action_message(value: Optional[str]) -> Optional[str]:
         """Return a clear message explaining what the user should do next."""
         if not APIKeyManager.is_configured_key(value):
-            return "Your API key is missing, Open Settings -> API Keys to configure one."
+            return (
+                "Your API key is missing. You can add one in Settings -> API Keys for this session. "
+                "For permanent access: ask your system administrator to configure it in the environment."
+            )
         return None
 
     @staticmethod

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import html
 import json
 import logging
 import os
@@ -62,6 +63,25 @@ def log_analysis_step(message: str, level: str = "info"):
     """Helper function to log analysis steps with consistent formatting"""
     log_func = getattr(logger, level)
     log_func(f"[ANALYSIS] {message}")
+
+
+def render_api_key_missing_alert(container, message: str, prefix: str = "Error:") -> None:
+    escaped_prefix = html.escape(prefix)
+    escaped_message = html.escape(message)
+    prefix_markup = f"<strong>{escaped_prefix}</strong> " if prefix else ""
+    container.markdown(
+        f"""
+        <div class="api-key-missing-alert">
+            <span class="api-key-missing-alert-icon">!</span>
+            <span>{prefix_markup}{escaped_message}</span>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def is_api_key_missing_message(message: str) -> bool:
+    return "No API key configured" in message or "Your API key is missing" in message
 
 
 # Add the report-analyst directory to the Python path
@@ -552,7 +572,10 @@ async def analyze_document_and_display(
 
                 if "error" in result:
                     log_analysis_step(f"Error received from analyzer: {result['error']}", "error")
-                    st.error(f"Analysis error: {result['error']}")
+                    if is_api_key_missing_message(result["error"]):
+                        render_api_key_missing_alert(st, result["error"], "Analysis error:")
+                    else:
+                        st.error(f"Analysis error: {result['error']}")
                     continue
 
                 if "status" in result:
@@ -1323,7 +1346,7 @@ def update_analyzer_parameters():
     available_models = get_available_llm_models()
 
     if not available_models:
-        st.info(get_api_key_setup_message())
+        render_api_key_missing_alert(st, get_api_key_setup_message(), "")
         return
 
     # Validate selected model availability
@@ -1433,7 +1456,10 @@ async def run_analysis(analyzer, file_path, selected_questions, progress_text):
         ):
             # Handle errors by displaying them but not storing them
             if "error" in result:
-                progress_text.error(f"Error: {result['error']}")
+                if is_api_key_missing_message(result["error"]):
+                    render_api_key_missing_alert(progress_text, result["error"])
+                else:
+                    progress_text.error(f"Error: {result['error']}")
                 continue
 
             # Handle status updates by displaying them but not storing them
@@ -1614,6 +1640,33 @@ def main():
             [data-testid="stNotification"] p::before {
                 content: none !important;
                 display: none !important;
+            }
+
+            .api-key-missing-alert {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                color: #b42318;
+                background-color: #fff4f2;
+                border: 1px solid #fecdca;
+                border-radius: 6px;
+                padding: 12px 16px;
+                margin: 8px 0 16px;
+                line-height: 1.4;
+            }
+
+            .api-key-missing-alert-icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 20px;
+                height: 20px;
+                min-width: 20px;
+                border-radius: 50%;
+                background-color: #d92d20;
+                color: #ffffff;
+                font-weight: 700;
+                line-height: 1;
             }
             
             /* Settings expander icon in sidebar */
@@ -2838,7 +2891,7 @@ def main():
 
         # Show page-specific content based on navigation
         if not has_any_llm_key() and nav_page != "Settings":
-            st.warning(get_api_key_setup_message())
+            render_api_key_missing_alert(st, get_api_key_setup_message(), "")
 
         if nav_page == "Settings":
             st.title("Settings")
@@ -2852,7 +2905,7 @@ def main():
             st.subheader("API Keys")
             st.caption("Enter your API keys to enable LLM features. Keys are stored in session state only and not persisted.")
             if not has_any_llm_key():
-                st.warning(get_api_key_setup_message())
+                render_api_key_missing_alert(st, get_api_key_setup_message(), "")
 
             # Check if keys exist in environment but not in session state
             env_openai_key = os.getenv("OPENAI_API_KEY")

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -69,7 +69,7 @@ def render_api_key_missing_alert(container, message: str, prefix: str = "Error:"
     escaped_prefix = html.escape(prefix)
     escaped_message = html.escape(message).replace(
         " For permanent access:",
-        ' <strong>For permanent access:</strong>',
+        " <strong>For permanent access:</strong>",
     )
     prefix_markup = f"<strong>{escaped_prefix}</strong> " if prefix else ""
     container.markdown(

--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -67,13 +67,16 @@ def log_analysis_step(message: str, level: str = "info"):
 
 def render_api_key_missing_alert(container, message: str, prefix: str = "Error:") -> None:
     escaped_prefix = html.escape(prefix)
-    escaped_message = html.escape(message)
+    escaped_message = html.escape(message).replace(
+        " For permanent access:",
+        ' <strong>For permanent access:</strong>',
+    )
     prefix_markup = f"<strong>{escaped_prefix}</strong> " if prefix else ""
     container.markdown(
         f"""
         <div class="api-key-missing-alert">
             <span class="api-key-missing-alert-icon">!</span>
-            <span>{prefix_markup}{escaped_message}</span>
+            <span class="api-key-missing-alert-message">{prefix_markup}{escaped_message}</span>
         </div>
         """,
         unsafe_allow_html=True,
@@ -1667,6 +1670,10 @@ def main():
                 color: #ffffff;
                 font-weight: 700;
                 line-height: 1;
+            }
+
+            .api-key-missing-alert-message {
+                display: block;
             }
             
             /* Settings expander icon in sidebar */

--- a/tests/test_api_key_manager.py
+++ b/tests/test_api_key_manager.py
@@ -22,7 +22,11 @@ def test_get_key_action_message_tells_user_next_step():
     """Action messages should tell users to configure a missing key."""
     missing_message = APIKeyManager.get_key_action_message(None)
 
-    assert missing_message == "Your API key is missing, Open Settings -> API Keys to configure one."
+    assert (
+        missing_message
+        == "Your API key is missing. You can add one in Settings -> API Keys for this session. "
+        "For permanent access: ask your system administrator to configure it in the environment."
+    )
     assert APIKeyManager.get_key_action_message("sk-real-looking-key") is None
 
 

--- a/tests/test_api_key_manager.py
+++ b/tests/test_api_key_manager.py
@@ -23,8 +23,7 @@ def test_get_key_action_message_tells_user_next_step():
     missing_message = APIKeyManager.get_key_action_message(None)
 
     assert (
-        missing_message
-        == "Your API key is missing. You can add one in Settings -> API Keys for this session. "
+        missing_message == "Your API key is missing. You can add one in Settings -> API Keys for this session. "
         "For permanent access: ask your system administrator to configure it in the environment."
     )
     assert APIKeyManager.get_key_action_message("sk-real-looking-key") is None


### PR DESCRIPTION
## Summary

Styled the missing API key warning so it is easier to notice and visually consistent across the app.

## Changes

- Added a custom alert renderer for missing API key messages.
- Styled the alert with a light red background, border, and a red `!` icon.
- Aligned the `!` icon and message text on the same line.
- Updated both API key message paths:
  - the analysis error message: `No API key configured...`
  - the setup/settings message: `Your API key is missing...`

<img width="990" height="589" alt="Screenshot 2026-07-02 at 4 15 11 PM" src="https://github.com/user-attachments/assets/cca51b7a-59d5-48b4-9934-a73405603666" />

