### PR TITLE
Patch first low-risk Dependabot alert batch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ fonttools==4.55.8
 frozenlist==1.5.0
 fsspec==2025.2.0
 gitdb==4.0.12
-GitPython==3.1.44
+GitPython==3.1.50
 google-auth==2.38.0
 google-generativeai>=0.3.0
 googleapis-common-protos==1.66.0
@@ -58,8 +58,8 @@ greenlet==3.1.1
 groovy==0.1.2
 grpc-interceptor==0.15.4
 grpcio==1.70.0
-h11==0.14.0
-httpcore==1.0.7
+h11==0.16.0
+httpcore==1.0.9
 httptools==0.6.4
 httpx==0.27.0
 httpx-sse==0.4.0
@@ -70,7 +70,7 @@ importlib_metadata==7.2.1
 importlib_resources==6.5.2
 iniconfig==2.0.0
 isort==6.0.1
-Jinja2==3.1.3
+Jinja2==3.1.6
 jiter==0.8.2
 joblib==1.4.2
 jsonpatch==1.33
@@ -140,7 +140,7 @@ pluggy==1.5.0
 posthog==3.11.0
 primp==0.14.0
 propcache==0.2.1
-protobuf==4.25.3
+protobuf==5.29.6
 psutil==7.0.0
 pulsar-client==3.6.1
 pyarrow==19.0.0
@@ -174,7 +174,7 @@ pytz==2025.1
 PyYAML==6.0.1
 referencing==0.36.2
 regex==2024.11.6
-requests==2.32.3
+requests==2.33.0
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
 responses==0.25.6
@@ -186,7 +186,7 @@ safehttpx==0.1.6
 scikit-learn==1.6.1
 scipy==1.15.2
 semantic-version==2.10.0
-setuptools==75.8.0
+setuptools==78.1.1
 shellingham==1.5.4
 six==1.17.0
 smmap==5.0.2
@@ -209,14 +209,14 @@ tiktoken==0.9.0
 tokenizers==0.21.0
 toml==0.10.2
 tomlkit==0.13.2
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.67.1
 typer==0.15.1
 typing-inspect==0.9.0
 typing_extensions==4.12.2
 tzdata==2025.1
 tzlocal==5.2
-urllib3==2.3.0
+urllib3==2.7.0
 uvicorn==0.27.1
 uvloop==0.21.0
 validators==0.34.0


### PR DESCRIPTION
This patches the first small batch of Dependabot security alerts in `requirements.txt` as part of #53.

I kept this PR focused on dependency updates that looked low-risk and easy to verify. Most of these are direct security bumps for pinned packages.

## Notes

- `h11` needed a matching `httpcore` bump, because the old `httpcore` pin did not allow `h11==0.16.0`.
- I originally checked `protobuf==4.25.8`, but it still showed one advisory, so this uses `protobuf==5.29.6`.

## Validation:

- installed requirements in the local conda environment.
- ran `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
- result: `215 passed, 5 skipped, 18 warnings in 19.77s`

I used `OPENAI_API_KEY=test-key` because the test suite imports code that checks for an API key during startup.

local setup note: the conda test environment needed `libpq` installed for `pytest-postgresql` / `psycopg`.

part of #53 