### PR TITLE
Patched utility dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,11 +39,11 @@ durationpy==0.9
 faiss-cpu==1.12.0
 fastapi==0.115.11
 ffmpy==0.5.0
-filelock==3.17.0
+filelock==3.20.3
 filetype==1.2.0
 flake8==7.1.2
 flatbuffers==25.1.24
-fonttools==4.55.8
+fonttools==4.60.2
 frozenlist==1.5.0
 fsspec==2025.2.0
 gitdb==4.0.12
@@ -65,7 +65,7 @@ httpx==0.27.0
 httpx-sse==0.4.0
 huggingface-hub==0.28.1
 humanfriendly==10.0
-idna==3.10
+idna==3.15
 importlib_metadata==7.2.1
 importlib_resources==6.5.2
 iniconfig==2.0.0
@@ -102,11 +102,11 @@ llama-index-readers-file==0.4.4
 llama-index-readers-llama-parse==0.4.0
 llama-parse==0.6.0
 lxml==5.3.1
-Mako==1.3.9
-Markdown==3.5.2
+Mako==1.3.12
+Markdown==3.8.1
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
-marshmallow==3.26.1
+marshmallow==3.26.2
 matplotlib==3.10.0
 mccabe==0.7.0
 mdurl==0.1.2
@@ -127,7 +127,7 @@ openai==1.61.1
 openinference-instrumentation==0.1.23
 openinference-instrumentation-langchain==0.1.35
 openinference-semantic-conventions==0.1.14
-orjson==3.10.15
+orjson==3.11.6
 overrides==7.7.0
 packaging==23.2
 pandas==2.2.3
@@ -143,7 +143,7 @@ protobuf==4.25.3
 psutil==7.0.0
 pulsar-client==3.6.1
 pyarrow==19.0.0
-pyasn1==0.6.1
+pyasn1==0.6.3
 pyasn1_modules==0.4.1
 pycodestyle==2.12.1
 pycparser==2.22
@@ -153,7 +153,7 @@ pydantic_core==2.27.2
 pydeck==0.9.1
 pydub==0.25.1
 pyflakes==3.2.0
-Pygments==2.19.1
+Pygments==2.20.0
 PyMuPDF==1.24.0
 PyMuPDFb==1.24.0
 pyparsing==3.2.1
@@ -167,7 +167,7 @@ pytest-cov==7.0.0
 pytest-env==1.1.1
 pytest-postgresql==7.0.2
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 python-multipart==0.0.20
 pytz==2025.1
 PyYAML==6.0.1
@@ -190,7 +190,7 @@ shellingham==1.5.4
 six==1.17.0
 smmap==5.0.2
 sniffio==1.3.1
-soupsieve==2.6
+soupsieve==2.8.4
 SQLAlchemy==2.0.37
 sqlean.py==3.47.0
 sqlite-vec==0.1.6


### PR DESCRIPTION
Part of #53.
This updates a small group of utility and parser dependencies.

The changes are limited to `requirements.txt`.

## Validation:
- `pip install -r requirements.txt`
- `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
- Result: 218 passed, 5 skipped