### PR TITLE
Patched pytest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -161,8 +161,8 @@ pypdf==5.2.0
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 psycopg2-binary==2.9.10
-pytest==8.3.5
-pytest-asyncio==0.25.3
+pytest==9.0.3
+pytest-asyncio==1.4.0
 pytest-cov==7.0.0
 pytest-env==1.1.1
 pytest-postgresql==7.0.2


### PR DESCRIPTION
Part of #53.

This updates the pytest dependency.

Updating pytest alone caused a dependency conflict because the existing `pytest-asyncio` version required pytest below version 9. I updated `pytest-asyncio` to the compatible dependency.

## Validation:
- `pip install -r requirements.txt`
- `python -c "import pytest, pytest_asyncio; print(pytest.__version__, pytest_asyncio.__version__)"`
     - to confirm `pytest 9.0.3` and `pytest-asyncio 1.4.0`.
- `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`.
- Result: 218 passed, 5 skipped.

The test API key was used because the test suite checks for an API key during startup.