### PR TITLE
Patched lxml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ llama-index-question-gen-openai==0.3.0
 llama-index-readers-file==0.4.4
 llama-index-readers-llama-parse==0.4.0
 llama-parse==0.6.0
-lxml==5.3.1
+lxml==6.1.0
 Mako==1.3.9
 Markdown==3.5.2
 markdown-it-py==3.0.0


### PR DESCRIPTION
Part of #53

This updates `lxml`.

## Validation:
- `python -m pip install -r requirements.txt`.
- Confirmed the installed version with `import lxml`; result: `6.1.0`.
- Verified basic XML and HTML parsing with `lxml`.
- `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`.
   - Result: `218 passed, 5 skipped`.
- `python -m streamlit run report_analyst/streamlit_app.py`.
- Did a user flow test.