### PR TITLE
Updated FastAPI and Starlette dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ distro==1.9.0
 duckduckgo_search==7.5.1
 durationpy==0.9
 faiss-cpu==1.12.0
-fastapi==0.115.11
+fastapi==0.139.2
 ffmpy==0.5.0
 filelock==3.20.3
 filetype==1.2.0
@@ -193,7 +193,7 @@ SQLAlchemy==2.0.37
 sqlean.py==3.47.0
 sqlite-vec==0.1.6
 sqlite-vss==0.1.2
-starlette==0.46.1
+starlette==1.3.1
 strawberry-graphql==0.262.1
 streamlit==1.52.0
 streamlit-card==1.0.2


### PR DESCRIPTION
Part of #53.

This updates Starlette to address its Dependabot security alert. FastAPI was updated alongside it because the previous version did not support the patched Starlette version.

## Validation

- Installed `requirements.txt` successfully.
- Ran the test suite: `218 passed, 5 skipped, 21 warnings`.
- `pip check` reports no FastAPI/Starlette conflict.

**Note:** Remaining warnings are the local `wheel`/`packaging` mismatch and macOS-only `sqlite-vss` limitation.