### PR TITLE
Fixed deleted file linting

### DIFF
--- a/scripts/lib/git-changed.sh
+++ b/scripts/lib/git-changed.sh
@@ -46,7 +46,7 @@ qg_collect_changed() {
         report-analyst/*) echo "$p" ;;
         report_analyst/*|tests/*|scripts/*) qg_normalize_path "$p" ;;
       esac
-    done < <(git -C "$git_root" diff --name-only "${base_ref}...HEAD" 2>/dev/null || true)
+    done < <(git -C "$git_root" diff --name-only --diff-filter=ACMRTUXB "${base_ref}...HEAD" 2>/dev/null || true)
   else
     while IFS= read -r p; do
       [[ -z "$p" ]] && continue
@@ -56,7 +56,7 @@ qg_collect_changed() {
       esac
     done < <(
       {
-        git -C "$git_root" diff --name-only HEAD 2>/dev/null || true
+        git -C "$git_root" diff --name-only --diff-filter=ACMRTUXB HEAD 2>/dev/null || true
         git -C "$git_root" diff --cached --name-only 2>/dev/null || true
         git -C "$git_root" ls-files --others --exclude-standard 2>/dev/null || true
       } | sort -u


### PR DESCRIPTION
This PR fixes the linting problem in #73 and any future related issues.

## What changed

Updated the quality-gate changed.sh file detection so deleted files are excluded before running Ruff.

## Why

The quality gate was still passing deleted files to Ruff. After the Gradio app was removed, Ruff tried to lint the deleted file and failed with:

`E902 No such file or directory`

Instead, it should lint files that exist in the pull request, not files that have been removed.

## Impact

This keeps linting enabled for added, modified, renamed, and other relevant files while excluding deleted files. It does not change application behavior nor weaken Ruff rules for existing files.

This fixes the quality-gate failure affecting PR #73.

## Validation

- Shell syntax validation passed.
- Git diff validation passed.
- Verified that deleted files are excluded from the quality-gate file list.
- Existing files remain included for linting.