### PR TITLE
Patched pyasn1 security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ protobuf==5.29.6
 psutil==7.0.0
 pulsar-client==3.6.1
 pyarrow==19.0.0
-pyasn1==0.6.1
+pyasn1==0.6.4
 pyasn1_modules==0.4.1
 pycodestyle==2.12.1
 pycparser==2.22


### PR DESCRIPTION
Part of #53.

This updates `pyasn1` to address the remaining security alerts for that package.

## Validation

- Reinstalled the requirements locally
- Ran `pip check`
- Ran `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
    - Result: `218 passed, 5 skipped`