### PR TITLE
Patched GitPython security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ fonttools==4.55.8
 frozenlist==1.5.0
 fsspec==2025.2.0
 gitdb==4.0.12
-GitPython==3.1.50
+GitPython==3.1.52
 google-auth==2.38.0
 google-generativeai>=0.3.0
 googleapis-common-protos==1.66.0


### PR DESCRIPTION
This updates `GitPython` to fix four high severity dependabot alerts.

## Validation

- Reinstalled the requirements locally
- Ran `pip check`
- Ran the test suite:
`OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
   - Result: `218 passed, 5 skipped`