### PR TITLE
Patched Streamlit security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -202,7 +202,7 @@ sqlite-vec==0.1.6
 sqlite-vss==0.1.2
 starlette==0.46.1
 strawberry-graphql==0.262.1
-streamlit==1.52.0
+streamlit==1.53.1
 streamlit-card==1.0.2
 streamlit-option-menu==0.4.0
 striprtf==0.0.26


### PR DESCRIPTION
Part of #53.
 
Updates Streamlit to address its dependabot security alert. No application code changed.

## Validation

- Reinstalled the requirements
- Ran pip checkOnly the existing macOS sqlite-vss message remains.
- Ran: `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
   - Result: 218 passed, 5 skipped