### PR TITLE
Patched PyArrow security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -142,7 +142,7 @@ propcache==0.2.1
 protobuf==5.29.6
 psutil==7.0.0
 pulsar-client==3.6.1
-pyarrow==19.0.0
+pyarrow==23.0.1
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycodestyle==2.12.1


### PR DESCRIPTION
Part of #53.

Updates `pyarrow` to address its high-severity Dependabot security alert. I also confirmed that a small Arrow table can still be converted to pandas.

## Validation

- Reinstalled the requirements
- Ran `pip check`
- Ran: `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
   -Result: `218 passed, 5 skipped, 18 warnings`