### PR TITLE
Removed unused Strawberry GraphQL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -201,7 +201,6 @@ sqlean.py==3.47.0
 sqlite-vec==0.1.6
 sqlite-vss==0.1.2
 starlette==0.46.1
-strawberry-graphql==0.262.1
 streamlit==1.53.1
 streamlit-card==1.0.2
 streamlit-option-menu==0.4.0


### PR DESCRIPTION
Removes `strawberry-graphql` to clear its dependabot alerts.

It was a direct dependency, but the project does not import it and no installed package requires it. Removing it is safer than upgrading an unused GraphQL library.

## Validation

- Reinstalled the requirements
- Confirmed `strawberry-graphql` is no longer installed
- Ran `pip check`
- Ran: `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
   - Result: `218 passed, 5 skipped, 18 warnings`