### PR TITLE
Support typed ANSWER guidelines for yes/no and numerical questions

### DIFF
--- a/report_analyst/core/analyzer.py
+++ b/report_analyst/core/analyzer.py
@@ -970,7 +970,6 @@ class DocumentAnalyzer:
             # Create analysis prompt with indexed chunks
             messages = self.prompt_manager.get_analysis_messages(
                 question=question_data["text"],
-                context="",
                 guidelines=question_data.get("guidelines", ""),
                 chunks_data=[
                     {

--- a/report_analyst/core/prompt_manager.py
+++ b/report_analyst/core/prompt_manager.py
@@ -95,7 +95,7 @@ class PromptManager:
         self.prompts_dir = Path(prompts_dir)
 
     def get_analysis_messages(
-        self, question: str, context: str, guidelines: str, chunks_data: List[Dict]
+        self, question: str, guidelines: str, chunks_data: List[Dict]
     ) -> List[ChatMessage]:
         """Generate messages for sustainability report question analysis."""
         formatted_chunks = "\n\n".join(

--- a/report_analyst/core/prompt_manager.py
+++ b/report_analyst/core/prompt_manager.py
@@ -94,9 +94,7 @@ class PromptManager:
     def __init__(self, prompts_dir: str = "prompts"):
         self.prompts_dir = Path(prompts_dir)
 
-    def get_analysis_messages(
-        self, question: str, guidelines: str, chunks_data: List[Dict]
-    ) -> List[ChatMessage]:
+    def get_analysis_messages(self, question: str, guidelines: str, chunks_data: List[Dict]) -> List[ChatMessage]:
         """Generate messages for sustainability report question analysis."""
         formatted_chunks = "\n\n".join(
             [

--- a/report_analyst/core/prompt_manager.py
+++ b/report_analyst/core/prompt_manager.py
@@ -1,38 +1,60 @@
 import json
-import os
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
-import yaml
-from langchain.prompts import PromptTemplate
-from langchain.schema import HumanMessage, SystemMessage
 from llama_index.core.llms import ChatMessage, MessageRole
 
+# Prompt template strings intentionally exceed line-length limits.
+# ruff: noqa: E501
 
-class PromptManager:
-    def __init__(self, prompts_dir: str = "prompts"):
-        self.prompts_dir = Path(prompts_dir)
+ANSWER_TYPE_LINE_RE = re.compile(
+    r"^\s*-\s*ANSWER type:\s*(.+)$",
+    re.MULTILINE | re.IGNORECASE,
+)
 
-    def get_analysis_messages(
-        self, question: str, context: str, guidelines: str, chunks_data: List[Dict]
-    ) -> List[ChatMessage]:
-        """Generate messages for TCFD question analysis"""
-        # Format chunks with numbers and scores for reference
-        formatted_chunks = "\n\n".join(
-            [
-                f"[CHUNK {i+1}] (Relevance Score: {chunk.get('computed_score', chunk.get('relevance_score', 0.0)):.3f})\n{chunk['text']}"
-                for i, chunk in enumerate(chunks_data)
-            ]
+DEFAULT_RULE_4 = "Keep your ANSWER within 60 words."
+TYPED_RULE_4 = (
+    "Put all reasoning and quoted report text in EVIDENCE; "
+    "ANSWER must match the ANSWER type in the question-specific guidelines only."
+)
+DEFAULT_JSON_ANSWER = "Your detailed analysis of the question"
+TYPED_JSON_ANSWER = "<value per ANSWER type in guidelines>"
+
+
+def parse_answer_type_line(guidelines: str) -> Optional[str]:
+    """Return the ANSWER type specification line from question guidelines, if present."""
+    if not guidelines:
+        return None
+    match = ANSWER_TYPE_LINE_RE.search(guidelines)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def has_typed_answer(guidelines: str) -> bool:
+    return parse_answer_type_line(guidelines) is not None
+
+
+def build_analysis_user_content(
+    question: str,
+    formatted_chunks: str,
+    guidelines: str,
+) -> str:
+    """Build the user message for report question analysis."""
+    answer_type_line = parse_answer_type_line(guidelines)
+    typed = answer_type_line is not None
+    rule_4 = TYPED_RULE_4 if typed else DEFAULT_RULE_4
+    json_answer = TYPED_JSON_ANSWER if typed else DEFAULT_JSON_ANSWER
+
+    typed_preamble = ""
+    if typed:
+        typed_preamble = (
+            "\nANSWER must match the ANSWER type in the question-specific guidelines "
+            "exactly; use EVIDENCE for reasoning and quoted report text.\n"
         )
 
-        return [
-            ChatMessage(
-                role=MessageRole.SYSTEM,
-                content="You are an AI assistant in the role of a Senior Equity Analyst with expertise in climate science that analyzes companys' sustainability reports.",
-            ),
-            ChatMessage(
-                role=MessageRole.USER,
-                content=f"""With the following extracted components of the sustainability report at hand, please analyze the question and provide a comprehensive response with evidence and scoring.
+    return f"""With the following extracted components of the sustainability report at hand, please analyze the question and provide a comprehensive response with evidence and scoring.
 
 QUESTION: {question}
 =========
@@ -45,27 +67,55 @@ Please adhere to the following guidelines in your answer:
 1. Your response must be precise, thorough, and grounded on specific extracts from the report to verify its authenticity.
 2. Consider the relevance scores when selecting evidence - higher scores suggest more relevant content.
 3. If you are unsure, simply acknowledge the lack of knowledge, rather than fabricating an answer.
-4. Keep your ANSWER within 60 words.
+4. {rule_4}
 5. Be skeptical to the information disclosed in the report as there might be greenwashing (exaggerating the firm's environmental responsibility). Always answer in a critical tone.
 6. cheap talks are statements that are costless to make and may not necessarily reflect the true intentions or future actions of the company. Be critical for all cheap talks you discovered in the report.
 7. Always acknowledge that the information provided is representing the company's view based on its report.
 8. Scrutinize whether the report is grounded in quantifiable, concrete data or vague, unverifiable statements, and communicate your findings.
 9. For each piece of evidence, you MUST reference the specific chunk number [CHUNK X] where it came from.
 {guidelines}
-
+{typed_preamble}
 IMPORTANT: Your response MUST be in valid JSON format like this example:
 {{
-    "ANSWER": "Your detailed analysis of the question",
+    "ANSWER": "{json_answer}",
     "SCORE": "Score from 0-10 indicating disclosure quality and completeness",
     "EVIDENCE": [
         {{"text": "Key evidence point", "chunk": X}},
         {{"text": "Another evidence point", "chunk": Y}}
     ],
     "GAPS": ["List of missing information or gaps in disclosure"],
-    "SOURCES": [X, Y, Z]  # List of chunk numbers referenced
+    "SOURCES": [X, Y, Z]
 }}
 
-Your FINAL_ANSWER in JSON (ensure there's no format error):""",
+Your FINAL_ANSWER in JSON (ensure there's no format error):"""
+
+
+class PromptManager:
+    def __init__(self, prompts_dir: str = "prompts"):
+        self.prompts_dir = Path(prompts_dir)
+
+    def get_analysis_messages(
+        self, question: str, context: str, guidelines: str, chunks_data: List[Dict]
+    ) -> List[ChatMessage]:
+        """Generate messages for sustainability report question analysis."""
+        formatted_chunks = "\n\n".join(
+            [
+                f"[CHUNK {i+1}] (Relevance Score: {chunk.get('computed_score', chunk.get('relevance_score', 0.0)):.3f})\n{chunk['text']}"
+                for i, chunk in enumerate(chunks_data)
+            ]
+        )
+
+        return [
+            ChatMessage(
+                role=MessageRole.SYSTEM,
+                content=(
+                    "You are an AI assistant in the role of a Senior Equity Analyst with expertise "
+                    "in climate science that analyzes companys' sustainability reports."
+                ),
+            ),
+            ChatMessage(
+                role=MessageRole.USER,
+                content=build_analysis_user_content(question, formatted_chunks, guidelines),
             ),
         ]
 
@@ -74,7 +124,7 @@ Your FINAL_ANSWER in JSON (ensure there's no format error):""",
             result_json = json.loads(result["result"])
             results["answers"][q_id] = result_json.get("ANSWER", "No answer provided")
             results["sources"][q_id] = result_json.get("SOURCES", [])
-        except Exception as e:
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
             print(f"Error processing result: {e}")
             results["answers"][q_id] = "Error processing result"
             results["sources"][q_id] = []

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -1,0 +1,86 @@
+"""Tests for PromptManager typed-answer prompt overrides."""
+
+from report_analyst.core.prompt_manager import (
+    DEFAULT_JSON_ANSWER,
+    DEFAULT_RULE_4,
+    TYPED_JSON_ANSWER,
+    TYPED_RULE_4,
+    PromptManager,
+    build_analysis_user_content,
+    has_typed_answer,
+    parse_answer_type_line,
+)
+
+TCFD_GUIDELINES = """\
+- Focus on board-specific oversight activities
+- Look for details about processes and frequency of oversight
+"""
+
+ESRS_CLASSIFICATION_GUIDELINES = """\
+- ANSWER type: classification — exactly one of Yes / No / Unclear / Not disclosed
+- Name the specific plan or program
+"""
+
+ESRS_QUANTITY_GUIDELINES = """\
+- ANSWER type: quantity — numeric value with unit (tCO2e, %, EUR/t, etc.) or Unclear / Not disclosed if not reported
+- Do not count RECs as carbon credit purchases
+"""
+
+
+class TestParseAnswerType:
+    def test_returns_none_for_tcfd_style_guidelines(self):
+        assert parse_answer_type_line(TCFD_GUIDELINES) is None
+        assert has_typed_answer(TCFD_GUIDELINES) is False
+
+    def test_parses_classification_line(self):
+        parsed = parse_answer_type_line(ESRS_CLASSIFICATION_GUIDELINES)
+        assert parsed == "classification — exactly one of Yes / No / Unclear / Not disclosed"
+
+    def test_parses_quantity_line(self):
+        parsed = parse_answer_type_line(ESRS_QUANTITY_GUIDELINES)
+        assert parsed.startswith("quantity —")
+
+
+class TestBuildAnalysisUserContent:
+    def test_tcfd_keeps_sixty_word_rule_and_prose_json_example(self):
+        content = build_analysis_user_content("Q?", "[CHUNK 1]\ntext", TCFD_GUIDELINES)
+        assert DEFAULT_RULE_4 in content
+        assert TYPED_RULE_4 not in content
+        assert f'"ANSWER": "{DEFAULT_JSON_ANSWER}"' in content
+        assert "ANSWER must match the ANSWER type" not in content
+
+    def test_esrs_classification_overrides_answer_rules(self):
+        content = build_analysis_user_content("Q?", "[CHUNK 1]\ntext", ESRS_CLASSIFICATION_GUIDELINES)
+        assert TYPED_RULE_4 in content
+        assert DEFAULT_RULE_4 not in content
+        assert f'"ANSWER": "{TYPED_JSON_ANSWER}"' in content
+        assert "ANSWER must match the ANSWER type" in content
+        assert ESRS_CLASSIFICATION_GUIDELINES in content
+
+    def test_esrs_quantity_overrides_answer_rules(self):
+        content = build_analysis_user_content("Q?", "[CHUNK 1]\ntext", ESRS_QUANTITY_GUIDELINES)
+        assert TYPED_RULE_4 in content
+        assert f'"ANSWER": "{TYPED_JSON_ANSWER}"' in content
+
+    def test_evidence_gaps_score_unchanged_for_typed(self):
+        content = build_analysis_user_content("Q?", "[CHUNK 1]\ntext", ESRS_CLASSIFICATION_GUIDELINES)
+        assert '"EVIDENCE"' in content
+        assert '"GAPS"' in content
+        assert '"SCORE"' in content
+        assert '"SOURCES"' in content
+        assert "For each piece of evidence" in content
+
+
+class TestPromptManagerMessages:
+    def test_get_analysis_messages_uses_typed_content(self):
+        pm = PromptManager()
+        messages = pm.get_analysis_messages(
+            question="Test?",
+            context="",
+            guidelines=ESRS_CLASSIFICATION_GUIDELINES,
+            chunks_data=[{"text": "chunk", "relevance_score": 0.5}],
+        )
+        assert len(messages) == 2
+        user_content = messages[1].content
+        assert TYPED_RULE_4 in user_content
+        assert "[CHUNK 1]" in user_content

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -76,7 +76,6 @@ class TestPromptManagerMessages:
         pm = PromptManager()
         messages = pm.get_analysis_messages(
             question="Test?",
-            context="",
             guidelines=ESRS_CLASSIFICATION_GUIDELINES,
             chunks_data=[{"text": "chunk", "relevance_score": 0.5}],
         )

--- a/tests/test_question_loader.py
+++ b/tests/test_question_loader.py
@@ -5,6 +5,7 @@ Tests for the QuestionSetLoader functionality
 import os
 import tempfile
 
+import pytest
 import yaml
 
 from report_analyst.core.question_loader import (

--- a/tests/test_question_loader.py
+++ b/tests/test_question_loader.py
@@ -399,3 +399,107 @@ class TestQuestionSetLoader:
             assert expected_set in options1, f"Expected question set '{expected_set}' not found in options"
 
         assert len(options1) == 6
+
+
+TYPED_ANSWER_QUESTIONSET = {
+    "name": "Typed Answer Test Set",
+    "shortcut": "typed-test",
+    "description": "Minimal questionset exercising ANSWER type guidelines",
+    "questions": [
+        {
+            "id": "typed_f1",
+            "text": "Is there a climate strategy?",
+            "guidelines": (
+                "- ANSWER type: classification — exactly one of Yes / No / Unclear / Not disclosed\n"
+                "- Name the specific plan or program"
+            ),
+        },
+        {
+            "id": "typed_f4",
+            "text": "How many tCO2e carbon credits were purchased?",
+            "guidelines": (
+                "- ANSWER type: quantity — numeric value with unit (tCO2e, %, EUR/t, etc.) "
+                "or Unclear / Not disclosed if not reported\n"
+                "- Do not count RECs as carbon credit purchases"
+            ),
+        },
+        {
+            "id": "typed_f5",
+            "text": "Are there quality assurance processes for certificates?",
+            "guidelines": (
+                "- ANSWER type: classification — exactly one of Yes / No / Unclear / Not disclosed "
+                "/ Not applicable (Not applicable only when the report shows no carbon credit purchases)\n"
+                "- deferred: strict F4→F5 chaining requires sequential analysis"
+            ),
+        },
+    ],
+}
+
+TYPED_ANSWER_EXAMPLES_QUESTIONSET = {
+    "name": "Typed Answer Examples",
+    "shortcut": "typed-examples",
+    "description": "Typed answers with few-shot examples",
+    "questions": [
+        {
+            "id": "typed_f1",
+            "text": "Is there a climate strategy?",
+            "guidelines": (
+                "- ANSWER type: classification — exactly one of Yes / No / Unclear / Not disclosed\n"
+                "Example: Yes — board-approved transition plan disclosed"
+            ),
+        },
+    ],
+}
+
+
+class TestTypedAnswerQuestionSets:
+    """Load questionsets whose guidelines declare ANSWER type (fixture YAML, no local ESRS files)."""
+
+    @pytest.fixture
+    def typed_loader(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for filename, payload in (
+                ("typed_test_questions.yaml", TYPED_ANSWER_QUESTIONSET),
+                ("typed_examples_questions.yaml", TYPED_ANSWER_EXAMPLES_QUESTIONSET),
+            ):
+                with open(os.path.join(temp_dir, filename), "w") as handle:
+                    yaml.dump(payload, handle)
+
+            original = os.environ.get("QUESTIONSETS_PATH")
+            os.environ["QUESTIONSETS_PATH"] = temp_dir
+            loader = QuestionSetLoader()
+            yield loader
+            loader.reload()
+            if original is not None:
+                os.environ["QUESTIONSETS_PATH"] = original
+            elif "QUESTIONSETS_PATH" in os.environ:
+                del os.environ["QUESTIONSETS_PATH"]
+
+    def test_baseline_loads_questions(self, typed_loader):
+        qset = typed_loader.get_question_set("typed_test")
+        assert qset is not None
+        assert len(qset.questions) == 3
+        assert qset.shortcut == "typed-test"
+
+    def test_baseline_guidelines_structure(self, typed_loader):
+        q = typed_loader.get_questions("typed_test")["typed_f1"]
+        guidelines = q["guidelines"]
+        assert guidelines.strip().startswith("- ANSWER type:")
+        assert "classification" in guidelines.splitlines()[0]
+        for section in ("## Overall answer policy", "## JSON mapping", "## Answer type"):
+            assert section not in guidelines
+        assert "Few-shot examples" not in guidelines
+
+    def test_quantity_questions_use_quantity_answer_type(self, typed_loader):
+        questions = typed_loader.get_questions("typed_test")
+        first_line = questions["typed_f4"]["guidelines"].strip().splitlines()[0]
+        assert "quantity" in first_line
+
+    def test_f5_cross_question_deferred_flag(self, typed_loader):
+        g = typed_loader.get_questions("typed_test")["typed_f5"]["guidelines"]
+        assert "Not applicable" in g.splitlines()[0]
+        assert "deferred" in g.lower()
+
+    def test_examples_variant_has_few_shots(self, typed_loader):
+        qset = typed_loader.get_question_set("typed_examples")
+        assert "Example:" in qset.questions["typed_f1"]["guidelines"]


### PR DESCRIPTION
Parse ANSWER type from question guidelines and adjust PromptManager rules so typed answers are not forced into 60-word prose.