### PR TITLE
Patched newer pypdf security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -145,7 +145,7 @@ Pygments==2.20.0
 PyMuPDF==1.24.0
 PyMuPDFb==1.24.0
 pyparsing==3.2.1
-pypdf==6.13.3
+pypdf==6.14.2
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
Part of #53. 

Updates `pypdf` from `6.13.3` to `6.14.2` to address new dependabot alerts that appeared after #58.

## Validation

- [x] Reinstall requirements after removing stale packages from the local environment
- [x] Run `pip check`
- [x] Run: `OPENAI_API_KEY=test-key PYTHONPATH="$PWD" python -m pytest`
- [x] Upload and parse a PDF manually

**Manual test note:** the full analysis flow is currently blocked by an existing question selection error: `KeyError: False`. 