### PR TITLE
Pinned NLTK security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -108,6 +108,7 @@ nats-py==2.10.0
 narwhals==1.25.0
 nest-asyncio==1.6.0
 networkx==3.4.2
+nltk==3.10.0
 numpy==1.26.4
 oauthlib==3.2.2
 onnxruntime==1.20.1


### PR DESCRIPTION
Part of #102. 

## Summary

- Pin `nltk==3.10.0`.
- Ensure existing installations upgrade the transitive NLTK dependency required by `llama-index-core`.
- Address the newer NLTK security advisories that appeared after the first-round 3.9.3 work.

The application does not import NLTK directly, but `llama-index-core==0.13.6` requires `nltk>3.8.1`. Without an explicit pin, an existing environment can retain an older vulnerable version that still satisfies that constraint.

## Validation

- Focused clean installation of NLTK, LlamaIndex Core, and Pillow completed successfully.
- `pip check` passed with no broken requirements.
- NLTK and LlamaIndex Core imported successfully together.
- Test suite passed: `369 passed, 10 skipped`.
