### PR TITLE
Patched Pillow security alerts

### DIFF
--- a/report_analyst/core/llm_providers.py
+++ b/report_analyst/core/llm_providers.py
@@ -2,10 +2,9 @@
 
 import logging
 import os
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
-from llama_index.llms.gemini import Gemini
+from llama_index.llms.google_genai import GoogleGenAI
 
 # LlamaIndex LLM imports
 from llama_index.llms.openai import OpenAI
@@ -52,13 +51,9 @@ def get_llm(model_name: str, cache_dir: Optional[str] = None, **kwargs) -> Any:
             logger.error(f"Cannot initialize Gemini model '{model_name}' - GOOGLE_API_KEY environment variable is not set")
             raise ValueError("GOOGLE_API_KEY environment variable is required for Gemini models")
 
-        # Use the full model path if provided, otherwise prefix with "models/"
-        full_model_name = model_name
-        if not model_name.startswith("models/"):
-            full_model_name = f"models/{model_name}"
-
-        logger.info(f"Initializing Gemini model: {full_model_name}")
-        return Gemini(model=full_model_name, api_key=api_key, **kwargs)
+        google_model_name = model_name.removeprefix("models/")
+        logger.info(f"Initializing Gemini model: {google_model_name}")
+        return GoogleGenAI(model=google_model_name, api_key=api_key, **kwargs)
 
     else:
         logger.error(f"Unsupported model type: {model_name}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ fsspec==2025.2.0
 gitdb==4.0.12
 GitPython==3.1.50
 google-auth==2.38.0
-google-generativeai>=0.3.0
+google-genai==1.24.0
 googleapis-common-protos==1.66.0
 graphql-core==3.2.6
 greenlet==3.1.1
@@ -59,7 +59,7 @@ grpcio==1.70.0
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
-httpx==0.27.0
+httpx==0.28.1
 httpx-sse==0.4.0
 huggingface-hub==0.28.1
 humanfriendly==10.0
@@ -87,7 +87,7 @@ llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6
 llama-index-embeddings-openai==0.5.2
-llama-index-llms-gemini==0.6.0
+llama-index-llms-google-genai==0.3.1
 llama-index-llms-openai==0.5.6
 llama-index-readers-file==0.5.6
 lxml==6.1.0
@@ -121,7 +121,7 @@ overrides==7.7.0
 packaging==23.2
 pandas==2.2.3
 pathspec==0.12.1
-pillow==10.4.0
+pillow==12.3.0
 platformdirs==4.3.6
 plotly==6.0.1
 pluggy==1.5.0

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+import pytest
+
+from report_analyst.core import llm_providers
+
+
+@pytest.mark.parametrize(
+    ("requested_model", "google_model"),
+    [
+        ("gemini-2.5-flash", "gemini-2.5-flash"),
+        ("models/gemini-2.5-flash", "gemini-2.5-flash"),
+    ],
+)
+def test_get_llm_uses_google_genai_adapter(monkeypatch, requested_model, google_model):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    google_genai = Mock()
+    monkeypatch.setattr(llm_providers, "GoogleGenAI", google_genai)
+
+    llm_providers.get_llm(requested_model, temperature=0.2)
+
+    google_genai.assert_called_once_with(
+        model=google_model,
+        api_key="test-google-key",
+        temperature=0.2,
+    )
+
+
+def test_get_llm_requires_google_api_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="GOOGLE_API_KEY"):
+        llm_providers.get_llm("gemini-2.5-flash")


### PR DESCRIPTION
## Summary

Upgrade Pillow from 10.4.0 to 12.3.0 to address 17 open Dependabot alerts.

## Why the Gemini changes are required

The existing `llama-index-llms-gemini` adapter is deprecated and requires `pillow<11`, which blocks the secure Pillow release. Gemini is an active application feature, so it cannot be removed.

This patch replaces it with `llama-index-llms-google-genai`, which supports Pillow 12.3.0 and remains compatible with `llama-index-core==0.13.6`.

The migration also:

- Replaces `google-generativeai` with `google-genai`.
- Upgrades `httpx` from 0.27.0 to 0.28.1, the minimum version required by `google-genai`.
- Updates `llm_providers.py` to use `GoogleGenAI`.
- Preserves support for plain and `models/`-prefixed Gemini model names.
- Continues using the existing `GOOGLE_API_KEY` configuration.
- Removes two unused imports detected by changed-file linting.
- Adds tests for Gemini model-name handling and the required API key.

## Validation

- `pip check` passed.
- Full test suite passed: `372 passed, 10 skipped`.
- Ruff, Black, and isort passed.
- Pillow image loading and PDF upload, metadata extraction, and parsing passed.
- Manual application startup succeeded with the replacement packages and existing Google API key configuration.

A direct clean installation still encounters the existing Chroma 0.7.3 build issue addressed by #104. 

Part of #102.