### PR TITLE
Patched Langchain Security Alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,10 +79,10 @@ kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
 langchain-community==0.3.19
-langchain-core==0.3.43
+langchain-core==0.3.85
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
-langsmith==0.3.13
+langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6


### PR DESCRIPTION
Part of #102.

Updates `langchain-core` from `0.3.43` to `0.3.85`, addressing Dependabot alerts #37, #44, #115, and #142.

Also updates `langsmith` from `0.3.13` to `0.3.45`, the minimum version required by the new LangChain Core version.

Alerts requiring a coordinated LangChain `1.x` migration remain out of scope.

## Validation

- `pip check` passed
- LangChain application imports passed
- Focused tests: `28 passed, 1 skipped`
- Full suite: `369 passed, 10 skipped`

The full installation used PR #104’s Chroma versions in the temporary test environment to bypass the existing Chroma build issue.