### PR TITLE
Remove unused langchain-community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,6 @@ jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
-langchain-community==0.3.19
 langchain-core==0.3.43
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6


### PR DESCRIPTION
Part of #102.

Removes the unused `langchain-community==0.3.19` dependency, addressing Dependabot alert #27.

The main `langchain` package does not require it, and a clean installation confirmed it is not installed transitively.

## Validation

- Frontend, backend, API, jobs, and prompt-manager imports passed
- `pip check` passed
- Full suite: `369 passed, 10 skipped`

The clean installation used PR #104’s Chroma versions in the temporary test environment to bypass the existing Chroma build issue.