### PR TITLE
Patched langchain text splitters dependency alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,10 +79,10 @@ kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
 langchain-community==0.3.19
-langchain-core==0.3.43
+langchain-core==0.3.85
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
-langsmith==0.3.13
+langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ langchain==0.3.20
 langchain-community==0.3.19
 langchain-core==0.3.85
 langchain-openai==0.3.8
-langchain-text-splitters==0.3.6
+langchain-text-splitters==0.3.9
 langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0


### PR DESCRIPTION
Part of #102.

Updates `langchain-text-splitters` from `0.3.6` to `0.3.9`, addressing live Dependabot alert #30 for an XXE vulnerability.

This is a stacked follow-up to PR #108: version 0.3.9 requires `langchain-core>=0.3.72`, which #108 updates to 0.3.85.

## Validation

- `pip check` passed
- LangChain application imports passed
- Full suite: `369 passed, 10 skipped`