### PR TITLE
Updated Pypdf security dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -146,7 +146,7 @@ Pygments==2.20.0
 PyMuPDF==1.24.0
 PyMuPDFb==1.24.0
 pyparsing==3.2.1
-pypdf==6.13.3
+pypdf==6.15.0
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
Part of #102.

Updates `pypdf` from `6.13.3` to `6.15.0`, addressing new Dependabot alerts #238 and #239.

These advisories were published on August 9 and affect all Pypdf versions below 6.15.0, including the 6.14.2 version currently on `main`.

## Validation

- `pip check` passed
- Pypdf and LlamaIndex PDF-reader imports passed
- Focused PDF/upload tests: `26 passed`
- Full suite: `369 passed, 10 skipped`

The clean installation used PR #104’s Chroma versions in the temporary validation environment to bypass the existing Chroma build issue.