### PR TITLE
 langchain security patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,10 +79,10 @@ kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
 langchain-community==0.3.19
-langchain-core==0.3.43
+langchain-core==0.3.85
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
-langsmith==0.3.13
+langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ langchain==0.3.20
 langchain-community==0.3.19
 langchain-core==0.3.85
 langchain-openai==0.3.8
-langchain-text-splitters==0.3.6
+langchain-text-splitters==0.3.9
 langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 kubernetes==32.0.0
-langchain==0.3.20
+langchain==0.3.30
 langchain-community==0.3.19
 langchain-core==0.3.85
 langchain-openai==0.3.8


### PR DESCRIPTION
Part of #102 .

Updates `langchain` from `0.3.20` to `0.3.30`, addressing live Dependabot alert #147.

This patch depends on PRs #108 and #111 because LangChain 0.3.30 requires `langchain-core>=0.3.85` and `langchain-text-splitters>=0.3.9`.

## Validation

- `pip check` passed
- LangChain application imports passed
- Full suite: `369 passed, 10 skipped`

The validation environment used PR #104’s Chroma versions to bypass the existing Chroma build issue.