### PR TITLE
Removed unused LangChain OpenAI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,6 @@ kubernetes==32.0.0
 langchain==0.3.20
 langchain-community==0.3.19
 langchain-core==0.3.43
-langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
 langsmith==0.3.13
 llama-cloud==0.1.11

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -190,7 +190,7 @@ def test_env(clean_db):
 def analyzer(test_env, clean_db):
     """Create a DocumentAnalyzer instance with mocked LLM"""
     with (
-        patch("langchain_openai.ChatOpenAI") as mock_llm,
+        patch("report_analyst.core.analyzer.get_llm") as mock_llm,
         patch("llama_index.embeddings.openai.OpenAIEmbedding") as mock_embedding,
         patch("llama_index.core.Settings"),
     ):
@@ -342,7 +342,7 @@ def test_update_llm_model(analyzer):
     mock_llm = Mock()
     mock_llm.model = new_model
 
-    with patch("langchain_openai.ChatOpenAI", return_value=mock_llm):
+    with patch("report_analyst.core.analyzer.get_llm", return_value=mock_llm):
         analyzer.update_llm_model(new_model)
         assert analyzer.llm.model == new_model
 
@@ -545,7 +545,7 @@ def test_get_all_cached_answers(analyzer):
 async def test_document_analysis_workflow(test_env):
     """Test the main document analysis workflow"""
     with (
-        patch("langchain_openai.ChatOpenAI") as mock_llm,
+        patch("report_analyst.core.analyzer.get_llm") as mock_llm,
         patch("llama_index.embeddings.openai.OpenAIEmbedding") as mock_embedding,
         patch("llama_index.core.Settings"),
     ):


### PR DESCRIPTION
Part of #103.

Removes unused `langchain-openai==0.3.8`, addressing Dependabot alert #128.

The application uses LlamaIndex’s OpenAI provider and does not import `langchain_openai`. Three analyzer tests were still mocking `langchain_openai.ChatOpenAI`, even though the analyzer calls `report_analyst.core.analyzer.get_llm`. Those mocks now target the provider factory actually used by the application.

## Validation

- Confirmed `langchain-openai` is not installed
- `pip check` passed
- Application import passed
- Analyzer tests: 17 passed, 1 skipped
- Full suite: 369 passed, 10 skipped
- Ruff, Black, and isort checks passed

Full-suite validation used PR #104’s Chroma versions because the current Chroma pin does not build in the validation environment.