### PR TITLE
Updated GitPython to 3.1.58

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ fonttools==4.60.2
 frozenlist==1.5.0
 fsspec==2025.2.0
 gitdb==4.0.12
-GitPython==3.1.50
+GitPython==3.1.58
 google-auth==2.38.0
 google-generativeai>=0.3.0
 googleapis-common-protos==1.66.0


### PR DESCRIPTION
Follow-up to #53.

Updates `GitPython` from `3.1.50` to `3.1.58`, addressing all 18 currently open GitPython alerts.

The previous GitPython patch was merged before six new alerts were published on August 9. GitPython is not imported directly by the application, but Streamlit requires it, so it must be updated rather than removed.

## Validation

- `pip check` passed
- GitPython, Streamlit, and application imports passed
- Full suite: 369 passed, 10 skipped
- `git diff --check` passed

Full-suite validation used PR #104’s Chroma versions because the current Chroma pin does not build in the Python 3.12 validation environment.