### PR TITLE
Updated aiohttp to 3.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiofiles==23.2.1
 aioresponses==0.7.7
 aiohappyeyeballs==2.5.0
-aiohttp==3.14.1
+aiohttp==3.14.3
 aioitertools==0.12.0
 aiosignal==1.4.0
 aiosqlite==0.21.0


### PR DESCRIPTION
Follow-up to #53.

Updates `aiohttp` from `3.14.1` to `3.14.3`, addressing three Dependabot alerts published after the previous HTTP dependency patch was merged.


## Validation

- `pip check` passed
- HTTP module imports passed
- Focused HTTP integration tests: 25 passed
- Full suite: 369 passed, 10 skipped
- `git diff --check` passed

Full-suite validation used PR #104’s Chroma versions because the current Chroma pin does not build in the Python 3.12 validation environment.