### PR TITLE
Merge second-round security updates into main

### DIFF
--- a/report_analyst/core/llm_providers.py
+++ b/report_analyst/core/llm_providers.py
@@ -2,10 +2,9 @@
 
 import logging
 import os
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
-from llama_index.llms.gemini import Gemini
+from llama_index.llms.google_genai import GoogleGenAI
 
 # LlamaIndex LLM imports
 from llama_index.llms.openai import OpenAI
@@ -52,13 +51,9 @@ def get_llm(model_name: str, cache_dir: Optional[str] = None, **kwargs) -> Any:
             logger.error(f"Cannot initialize Gemini model '{model_name}' - GOOGLE_API_KEY environment variable is not set")
             raise ValueError("GOOGLE_API_KEY environment variable is required for Gemini models")
 
-        # Use the full model path if provided, otherwise prefix with "models/"
-        full_model_name = model_name
-        if not model_name.startswith("models/"):
-            full_model_name = f"models/{model_name}"
-
-        logger.info(f"Initializing Gemini model: {full_model_name}")
-        return Gemini(model=full_model_name, api_key=api_key, **kwargs)
+        google_model_name = model_name.removeprefix("models/")
+        logger.info(f"Initializing Gemini model: {google_model_name}")
+        return GoogleGenAI(model=google_model_name, api_key=api_key, **kwargs)
 
     else:
         logger.error(f"Unsupported model type: {model_name}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,10 +79,10 @@ kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
 langchain-community==0.3.19
-langchain-core==0.3.43
+langchain-core==0.3.85
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6
-langsmith==0.3.13
+langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,6 @@ jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 kubernetes==32.0.0
 langchain==0.3.20
-langchain-community==0.3.19
 langchain-core==0.3.43
 langchain-openai==0.3.8
 langchain-text-splitters==0.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ langchain==0.3.20
 langchain-community==0.3.19
 langchain-core==0.3.85
 langchain-openai==0.3.8
-langchain-text-splitters==0.3.6
+langchain-text-splitters==0.3.9
 langsmith==0.3.45
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,7 +146,7 @@ Pygments==2.20.0
 PyMuPDF==1.24.0
 PyMuPDFb==1.24.0
 pyparsing==3.2.1
-pypdf==6.13.3
+pypdf==6.15.0
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 psycopg2-binary==2.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 kubernetes==32.0.0
-langchain==0.3.20
+langchain==0.3.30
 langchain-community==0.3.19
 langchain-core==0.3.85
 langchain-openai==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ fsspec==2025.2.0
 gitdb==4.0.12
 GitPython==3.1.50
 google-auth==2.38.0
-google-generativeai>=0.3.0
+google-genai==1.24.0
 googleapis-common-protos==1.66.0
 graphql-core==3.2.6
 greenlet==3.1.1
@@ -59,7 +59,7 @@ grpcio==1.70.0
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
-httpx==0.27.0
+httpx==0.28.1
 httpx-sse==0.4.0
 huggingface-hub==0.28.1
 humanfriendly==10.0
@@ -87,7 +87,7 @@ llama-cloud==0.1.11
 llama-cloud-services==0.6.0
 llama-index-core==0.13.6
 llama-index-embeddings-openai==0.5.2
-llama-index-llms-gemini==0.6.0
+llama-index-llms-google-genai==0.3.1
 llama-index-llms-openai==0.5.6
 llama-index-readers-file==0.5.6
 lxml==6.1.0
@@ -121,7 +121,7 @@ overrides==7.7.0
 packaging==23.2
 pandas==2.2.3
 pathspec==0.12.1
-pillow==10.4.0
+pillow==12.3.0
 platformdirs==4.3.6
 plotly==6.0.1
 pluggy==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,6 +108,7 @@ nats-py==2.10.0
 narwhals==1.25.0
 nest-asyncio==1.6.0
 networkx==3.4.2
+nltk==3.10.0
 numpy==1.26.4
 oauthlib==3.2.2
 onnxruntime==1.20.1

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+import pytest
+
+from report_analyst.core import llm_providers
+
+
+@pytest.mark.parametrize(
+    ("requested_model", "google_model"),
+    [
+        ("gemini-2.5-flash", "gemini-2.5-flash"),
+        ("models/gemini-2.5-flash", "gemini-2.5-flash"),
+    ],
+)
+def test_get_llm_uses_google_genai_adapter(monkeypatch, requested_model, google_model):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    google_genai = Mock()
+    monkeypatch.setattr(llm_providers, "GoogleGenAI", google_genai)
+
+    llm_providers.get_llm(requested_model, temperature=0.2)
+
+    google_genai.assert_called_once_with(
+        model=google_model,
+        api_key="test-google-key",
+        temperature=0.2,
+    )
+
+
+def test_get_llm_requires_google_api_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="GOOGLE_API_KEY"):
+        llm_providers.get_llm("gemini-2.5-flash")


### PR DESCRIPTION
Part of #102 and follows the earlier security-update rounds tracked in #50 and #53.

This PR merges the second round of dependency security updates into `main` and resolves the corresponding Dependabot alerts tracked in #102.

## Changes

- Updates NLTK, Pillow, pypdf, LangChain, LangChain Core, and LangChain text splitters to secure versions
- Removes the unused `langchain-community` dependency
- Updates compatible HTTPX and LangSmith versions
- Replaces the legacy Google Generative AI integration with `google-genai` and the LlamaIndex Google GenAI adapter
- Updates `llm_providers.py` to use the new adapter and normalize Gemini model names
- Adds `tests/test_llm_providers.py` to test model-name normalization, option forwarding, and missing API-key handling without calling the external API

The branch was synchronized with the latest `main` before opening this PR.

## Validation

- Dependency installation completed
- Full test suite passed
- CI passed