### PR TITLE
Updated pyasn1 to 0.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -128,7 +128,7 @@ propcache==0.2.1
 protobuf==5.29.6
 psutil==7.0.0
 pyarrow==19.0.0
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1_modules==0.4.1
 pycodestyle==2.12.1
 pycparser==2.22


### PR DESCRIPTION
This is a follow-up to #53 and will be included in the third round of security updates #103.

## What changed

Updated `pyasn1` from 0.6.3 to 0.6.4.

This fixes three current high-severity Dependabot alerts involving denial of service and uncontrolled resource consumption:

- GHSA-8ppf-4f7h-5ppj
- GHSA-hm4w-wwcw-mr6r
- GHSA-m4p7-r5rc-7g4j


## Validation

- `pip check`: no broken requirements
- Tests: 375 passed, 10 skipped
- Confirmed there are no direct `pyasn1` imports requiring code changes