### PR TITLE
Fixed model state fallback

### DIFF
--- a/report_analyst/streamlit_app.py
+++ b/report_analyst/streamlit_app.py
@@ -469,12 +469,13 @@ def display_download_buttons(analysis_df: pd.DataFrame, chunks_df: pd.DataFrame,
 
 def generate_file_key(file_path: str, st) -> str:
     """Generate a cache file key from file path and settings"""
+    llm_model = st.session_state.get("new_llm_model", st.session_state.llm_model)
     return (
         f"{Path(file_path).name}_"
         f"cs{st.session_state.new_chunk_size}_"
         f"ov{st.session_state.new_overlap}_"
         f"tk{st.session_state.new_top_k}_"
-        f"m{st.session_state.new_llm_model}"
+        f"m{llm_model}"
     )
 
 
@@ -1285,7 +1286,7 @@ def display_cache_selector(file_path: str):
         "chunk_size": st.session_state.new_chunk_size,
         "chunk_overlap": st.session_state.new_overlap,
         "top_k": st.session_state.new_top_k,
-        "model": st.session_state.new_llm_model,
+        "model": st.session_state.get("new_llm_model", st.session_state.llm_model),
         "question_set": st.session_state.new_question_set,
     }
 
@@ -1357,7 +1358,7 @@ def update_analyzer_parameters():
     chunk_size = st.session_state.new_chunk_size
     chunk_overlap = st.session_state.new_overlap
     top_k = st.session_state.new_top_k
-    llm_model = st.session_state.new_llm_model
+    llm_model = st.session_state.get("new_llm_model", st.session_state.llm_model)
     available_models = get_available_llm_models()
 
     if not available_models:
@@ -3935,7 +3936,7 @@ def main():
                                     "chunk_size": st.session_state.new_chunk_size,
                                     "chunk_overlap": st.session_state.new_overlap,
                                     "top_k": st.session_state.new_top_k,
-                                    "model": st.session_state.new_llm_model,
+                                    "model": st.session_state.get("new_llm_model", st.session_state.llm_model),
                                     "question_set": st.session_state.new_question_set,
                                 }
 


### PR DESCRIPTION
## What happened

While updating PR #115 with the latest third-round security branch, its CI run failed in two Analyze/Reanalyze tests.

Both failures reported that `st.session_state.new_llm_model` did not exist when the test clicked the Analyze or Reanalyze button.

## Root cause

PR #115 only removes `langchain-openai` and updates analyzer mocks, so I traced the failing test and session-state access through the Git history.

The tests were introduced in PR #110. They assumed that the model selector would always initialize `new_llm_model`. However, the test suite uses randomized ordering, and API-key tests can change the environment state. When no API key is available, the model selector is not rendered and `new_llm_model` is never initialized.

I reproduced the CI failure locally by running the tests with both API keys unset: two tests failed with the same missing session-state error.

The same root cause had already been identified in draft PR #120, where commit `b0acd504` added a fallback to the initialized `llm_model` value.

## What changed

This PR extracts that fallback into an isolated fix instead of making PR #115 depend on the unrelated PDF viewer work in PR #120.

When `new_llm_model` is unavailable, the application now uses the existing `llm_model` session value for:

- analysis configuration
- cache selection
- analyzer parameter updates
- cache-key generation

## Impact on the security updates

The failure blocked PR #115 even though it was unrelated to removing `langchain-openai`. Merging this fix into `main`, then updating the third-round security branch, allows PR #115 and the remaining dependency patches to continue without adding unrelated application changes to them.

## Validation

- Reproduced the original failure with both API keys unset
- Analyze/Reanalyze tests after the fix: 3 passed
- Full randomized suite: 375 passed, 10 skipped