### PR TITLE
Updated cryptography to 50.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 coloredlogs==15.0.1
 contourpy==1.3.1
-cryptography==48.0.1
+cryptography==50.0.0
 cycler==0.12.1
 dataclasses-json==0.6.7
 Deprecated==1.2.18


### PR DESCRIPTION
## What changed

Updated `cryptography` from 48.0.1 to 50.0.0.

This fixes the new high-severity advisory GHSA-g6cj-pr64-35w5 / CVE-2026-69247 involving distinguishable errors and timing during PKCS#7 EnvelopedData decryption.

## Validation

- Confirmed the branch contains the latest `main`
- `pip check`: no broken requirements
- Cryptographic signing and verification smoke test passed
- Full suite: 375 passed, 10 skipped