### PR TITLE
Removed unused Strawberry GraphQL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -185,7 +185,6 @@ sqlean.py==3.47.0
 sqlite-vec==0.1.6
 sqlite-vss==0.1.2
 starlette==1.3.1
-strawberry-graphql==0.262.1
 streamlit==1.52.0
 streamlit-card==1.0.2
 streamlit-option-menu==0.4.0


### PR DESCRIPTION
Removes the unused strawberry-graphql dependency and resolves its outstanding security alerts. Full test suite passes: 389 passed, 9 skipped.