### PR TITLE
Updated PyArrow to 23.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ primp==0.14.0
 propcache==0.2.1
 protobuf==5.29.6
 psutil==7.0.0
-pyarrow==19.0.0
+pyarrow==23.0.1
 pyasn1==0.6.4
 pyasn1_modules==0.4.1
 pycodestyle==2.12.1


### PR DESCRIPTION
Updates PyArrow from 19.0.0 to 23.0.1 to address CVE-2026-25087. The full test suite passes: 388 passed, 10 skipped.