### PR TITLE
Removed unused LangChain dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,9 +75,6 @@ jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 kubernetes==32.0.0
-langchain==0.3.30
-langchain-core==0.3.85
-langchain-text-splitters==0.3.9
 langsmith==0.8.18
 llama-cloud==0.1.11
 llama-cloud-services==0.6.0


### PR DESCRIPTION
Removes the unused langchain, langchain-core, and langchain-text-splitters dependencies instead of performing a risky coordinated 1.x migration. Repository-wide searches found no usage. Tests passed in an environment where the packages were physically absent: 388 passed, 10 skipped.