### PR TITLE
Updated Setuptools to 83.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -174,7 +174,7 @@ safehttpx==0.1.6
 scikit-learn==1.6.1
 scipy==1.15.2
 semantic-version==2.10.0
-setuptools==80.9.0
+setuptools==83.0.0
 shellingham==1.5.4
 six==1.17.0
 smmap==5.0.2


### PR DESCRIPTION
Updates Setuptools from 80.9.0 to 83.0.0 to resolve Dependabot alert #207. Tested with Setuptools 83.0.0 installed: 389 passed, 9 skipped.