### PR TITLE
Updated Streamlit to 1.54.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -182,7 +182,7 @@ sqlean.py==3.47.0
 sqlite-vec==0.1.6
 sqlite-vss==0.1.2
 starlette==1.3.1
-streamlit==1.52.0
+streamlit==1.54.0
 streamlit-card==1.0.2
 streamlit-option-menu==0.4.0
 striprtf==0.0.26


### PR DESCRIPTION
Updates Streamlit from 1.52.0 to 1.54.0 to resolve Dependabot alerts #96 and #194. Tested with Streamlit 1.54.0 and PyArrow 23.0.1 installed: 389 passed, 9 skipped.